### PR TITLE
Fire an actual change event on emoji input

### DIFF
--- a/js/jquery.emojipicker.js
+++ b/js/jquery.emojipicker.js
@@ -259,8 +259,13 @@
       addToLocalStorage(emojiShortcode);
       updateRecentlyUsed(emojiShortcode);
 
-      // trigger change event on input
+      // For anyone who is relying on the keyup event
       $(this.element).trigger("keyup");
+
+      // trigger change event on input
+      var event = document.createEvent("HTMLEvents");
+      event.initEvent("input", true, true);
+      this.element.dispatchEvent(event);
     },
 
     emojiMouseover: function(e) {


### PR DESCRIPTION
The way jQuery fires event doesn't always seem to trigger real browser events. This patch keeps the current behavior of keyup, but also adds an input event that trigger's React's Synthetic event hook.
