### PR TITLE
Checks for mobile before calling destroy()

### DIFF
--- a/js/jquery.emojipicker.js
+++ b/js/jquery.emojipicker.js
@@ -14,7 +14,7 @@
         button: true
       };
 
-  var MIN_WIDTH = 300,
+  var MIN_WIDTH = 280,
       MAX_WIDTH = 600,
       MIN_HEIGHT = 100,
       MAX_HEIGHT = 350,
@@ -67,6 +67,8 @@
     // Do not enable if on mobile device (emojis already present)
     if(!/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
       this.init();
+    } else {
+      this.isMobile = true;
     }
 
   }
@@ -128,6 +130,8 @@
     },
 
     destroyPicker: function() {
+      if (this.isMobile) return this;
+
       this.$picker.unbind('mouseover');
       this.$picker.unbind('mouseout');
       this.$picker.unbind('click');


### PR DESCRIPTION
The `init()` function is only called if not on a mobile device, so if you try to explicitly call `destroy()` while viewing on a mobile device, the `unbind()` functions will error because it does not exist.